### PR TITLE
Core/AI: correct Permit level for trigger flagged creatures

### DIFF
--- a/src/server/game/AI/CoreAI/PassiveAI.cpp
+++ b/src/server/game/AI/CoreAI/PassiveAI.cpp
@@ -29,7 +29,7 @@ int32 NullCreatureAI::Permissible(Creature const* creature)
         return PERMIT_BASE_PROACTIVE + 50;
 
     if (creature->IsTrigger())
-        return PERMIT_BASE_REACTIVE;
+        return PERMIT_BASE_PROACTIVE;
 
     return PERMIT_BASE_IDLE;
 }
@@ -105,7 +105,7 @@ void TriggerAI::IsSummonedBy(Unit* summoner)
 int32 TriggerAI::Permissible(Creature const* creature)
 {
     if (creature->IsTrigger() && creature->m_spells[0])
-        return PERMIT_BASE_PROACTIVE;
+        return PERMIT_BASE_SPECIAL;
 
     return PERMIT_BASE_NO;
 }


### PR DESCRIPTION
This broke several mechanics such as LK hc Frostmourne Room or Rotface's slime, how come no one noticed it? Like really, no one?
ref ce3787f190d28c1e981598eef2cd24c622a2cbae

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
