### PR TITLE
DB/Quests: use correct gender format in Argent Dawn repeatable quests

### DIFF
--- a/sql/updates/world/3.3.5/2017_07_25_01_world_335.sql
+++ b/sql/updates/world/3.3.5/2017_07_25_01_world_335.sql
@@ -1,0 +1,9 @@
+-- Correct gender selection DB format for brother/sister is $gbrother:sister;
+UPDATE `quest_offer_reward`
+ SET `RewardText` = 'Congratulations, $N - I am pleased to award you with an Argent Dawn valor token!
+ 
+To acquire a valor token in such a manner indicates that you are a true hero in the cause of good. We value all effort brought to bear against the Scourge, but to take down one of their leaders is to truly deliver onto them a crushing defeat!
+ 
+For the Dawn, my $gbrother:sister;!'
+
+ WHERE `ID` IN (5404, 5406, 5508); -- Corruptor's Scourgestones (Argent Dawn repeatable quests)


### PR DESCRIPTION
- Gender selection for the words brother/sister = $gbrother:sister;
- in existing quest RewardText $g is flipped and shown as straight text
  (instead of "brother" or "sister" the quest says "g$sister:brother")

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
