### PR TITLE
DB/Quests: add missing progress text to 'Bandages for the Field'

### DIFF
--- a/sql/updates/world/3.3.5/2017_07_28_00_world_335.sql
+++ b/sql/updates/world/3.3.5/2017_07_28_00_world_335.sql
@@ -1,0 +1,2 @@
+-- insert missing Progress text for the 2 quests "Bandages for the Field" (8496,8810)
+UPDATE `quest_request_items` SET `CompletionText`= 'You have something for me, $N?$b$b' WHERE `ID` IN (8496,8810);


### PR DESCRIPTION
- Silithus / Cenarion Circle repeatable quests (Field Duty)
- 'Bandages for the Field' progress text (quest_request_items):
  "You have something for me, <name>?", requesting 4 quest items.

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
