### PR TITLE
Core/Misc: Util changes

### DIFF
--- a/src/common/Collision/RegularGrid.h
+++ b/src/common/Collision/RegularGrid.h
@@ -18,8 +18,8 @@
 #ifndef _REGULAR_GRID_H
 #define _REGULAR_GRID_H
 
-#include "Containers.h"
 #include "Errors.h"
+#include "IteratorPair.h"
 #include <G3D/Ray.h>
 #include <G3D/BoundsTrait.h>
 #include <G3D/PositionTrait.h>

--- a/src/common/Utilities/Containers.h
+++ b/src/common/Utilities/Containers.h
@@ -198,32 +198,6 @@ namespace Trinity
             return itr != map.end() ? AddressOrSelf(itr->second) : nullptr;
         }
 
-        /**
-         * @class IteratorPair
-         *
-         * @brief Utility class to enable range for loop syntax for multimap.equal_range uses
-         */
-        template<class iterator>
-        class IteratorPair
-        {
-        public:
-            IteratorPair() : _iterators() { }
-            IteratorPair(iterator first, iterator second) : _iterators(first, second) { }
-            IteratorPair(std::pair<iterator, iterator> iterators) : _iterators(iterators) { }
-
-            iterator begin() const { return _iterators.first; }
-            iterator end() const { return _iterators.second; }
-
-        private:
-            std::pair<iterator, iterator> _iterators;
-        };
-
-        template<class M>
-        inline auto MapEqualRange(M& map, typename M::key_type const& key) -> IteratorPair<decltype(map.begin())>
-        {
-            return { map.equal_range(key) };
-        }
-
         template<class K, class V, template<class, class, class...> class M, class... Rest>
         void MultimapErasePair(M<K, V, Rest...>& multimap, K const& key, V const& value)
         {

--- a/src/common/Utilities/IteratorPair.h
+++ b/src/common/Utilities/IteratorPair.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef IteratorPair_h__
+#define IteratorPair_h__
+
+#include "Define.h"
+#include <utility>
+
+namespace Trinity
+{
+    /**
+     * @class IteratorPair
+     *
+     * @brief Utility class to enable range for loop syntax for multimap.equal_range uses
+     */
+    template<class iterator>
+    class IteratorPair
+    {
+    public:
+        IteratorPair() : _iterators() { }
+        IteratorPair(iterator first, iterator second) : _iterators(first, second) { }
+        IteratorPair(std::pair<iterator, iterator> iterators) : _iterators(iterators) { }
+
+        iterator begin() const { return _iterators.first; }
+        iterator end() const { return _iterators.second; }
+
+    private:
+        std::pair<iterator, iterator> _iterators;
+    };
+
+    namespace Containers
+    {
+        template<class M>
+        inline auto MapEqualRange(M& map, typename M::key_type const& key) -> IteratorPair<decltype(map.begin())>
+        {
+            return { map.equal_range(key) };
+        }
+    }
+    //! namespace Containers
+}
+//! namespace Trinity
+
+#endif // IteratorPair_h__

--- a/src/common/Utilities/Util.h
+++ b/src/common/Utilities/Util.h
@@ -493,4 +493,11 @@ bool CompareValues(ComparisionType type, T val1, T val2)
     }
 }
 
+template<typename E>
+typename std::underlying_type<E>::type AsUnderlyingType(E enumValue)
+{
+    static_assert(std::is_enum<E>::value, "AsUnderlyingType can only be used with enums");
+    return static_cast<typename std::underlying_type<E>::type>(enumValue);
+}
+
 #endif

--- a/src/server/game/Chat/Chat.cpp
+++ b/src/server/game/Chat/Chat.cpp
@@ -416,7 +416,7 @@ bool ChatHandler::_ParseCommands(char const* text)
 {
     if (ExecuteCommandInTable(getCommandTable(), text, text))
         return true;
-    
+
     // Pretend commands don't exist for regular players
     if (m_session && !m_session->HasPermission(rbac::RBAC_PERM_COMMANDS_NOTIFY_COMMAND_NOT_FOUND_ERROR))
         return false;
@@ -1316,7 +1316,7 @@ bool AddonChannelCommandHandler::ParseCommands(char const* str)
     if (!str[13] || !str[14] || !str[15] || !str[16]) // str[13] through str[16] is 4-character command counter
         return false;
     echo = str+13;
-    
+
     switch (opcode)
     {
         case 'p': // p Ping

--- a/src/server/game/Combat/ThreatManager.h
+++ b/src/server/game/Combat/ThreatManager.h
@@ -20,11 +20,11 @@
 #define _THREATMANAGER
 
 #include "Common.h"
+#include "IteratorPair.h"
 #include "SharedDefines.h"
 #include "LinkedReference/Reference.h"
 #include "UnitEvents.h"
 #include "ObjectGuid.h"
-#include "Containers.h"
 
 #include <list>
 
@@ -220,8 +220,8 @@ class TC_GAME_API ThreatManager
 {
     public:
         // -- compatibility layer for combat rewrite (PR #19930)
-        Trinity::Containers::IteratorPair<std::list<ThreatReference*>::const_iterator> GetSortedThreatList() const { auto& list = iThreatContainer.getThreatList(); return { list.cbegin(), list.cend() }; }
-        Trinity::Containers::IteratorPair<std::list<ThreatReference*>::const_iterator> GetUnsortedThreatList() const { return GetSortedThreatList(); }
+        Trinity::IteratorPair<std::list<ThreatReference*>::const_iterator> GetSortedThreatList() const { auto& list = iThreatContainer.getThreatList(); return { list.cbegin(), list.cend() }; }
+        Trinity::IteratorPair<std::list<ThreatReference*>::const_iterator> GetUnsortedThreatList() const { return GetSortedThreatList(); }
         std::list<ThreatReference*> GetModifiableThreatList() const { return iThreatContainer.getThreatList(); }
         Unit* SelectVictim() { return getHostilTarget(); }
         Unit* GetCurrentVictim() const { if (ThreatReference* ref = getCurrentVictim()) return ref->GetVictim(); else return nullptr; }


### PR DESCRIPTION
* Move IteratorPair to its own header
* Add AsUnderlyingType function to cast enum value to its underlying type (avoids repeating std::underlying_type everywhere)

(cherry picked from commit fdd9227b232db9aae9bc4b2c60ca4de2cdaa0b54)

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
