### PR TITLE
DB/Quest: Sabotage the Warp-Gate! (10310): add missing end half of Re…

### DIFF
--- a/sql/updates/world/3.3.5/2017_08_05_01_world.sql
+++ b/sql/updates/world/3.3.5/2017_08_05_01_world.sql
@@ -1,0 +1,4 @@
+-- Sabotage the Warp-Gate! (quest ID 10310): add missing end half of RewardText
+UPDATE `quest_offer_reward`
+ SET `RewardText`="That is most excellent news, my friend!$B$BYou and Drijya have done us a great service.  With that warp-gate out of commission, the nearby demons will not be getting any further reinforcements.$B$BPlease allow me to reward you in the proper manner of the Consortium."
+ WHERE `ID` = 10310;


### PR DESCRIPTION
…wardText

- Previous content: 103 characters. Added content: 163 characters. Full text: 266 characters.
- RewardText completion source: sql/old/4.3.4/TDB0_to_TDB1_updates/world/012_quest_template.sql

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
