### PR TITLE
DB/Quest: A Boaring Time for Grulloc (10721): wrong RewardText content

### DIFF
--- a/sql/updates/world/3.3.5/2017_08_06_03_world.sql
+++ b/sql/updates/world/3.3.5/2017_08_06_03_world.sql
@@ -1,0 +1,4 @@
+-- A Boaring Time for Grulloc (quest ID 10721): use RewardText instead of QuestDescription
+UPDATE `quest_offer_reward`
+ SET `RewardText`="<Baron Sablemane peers inside the gronn's sack and seems satisfied.>$B$BVery well, you have upheld your end of the bargain. With that price paid, I will give Rexxar what he seeks."
+ WHERE `Id`=10721;


### PR DESCRIPTION
http://www.wowhead.com/quest=10721/a-boaring-time-for-grulloc
https://wow.gamepedia.com/Quest:A_Boaring_Time_for_Grulloc

- Quest 10721 showed up in-game with the same Reward Text as Quest Description
- quest_template.QuestDescription was inserted as quest_offer_reward.RewardText
- issue also found in https://github.com/dalaranwow/dalaran-wow/issues/1926
- Correct RewardText is based on content from the 3 linked pages above.

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
