### PR TITLE
DB/Misc: Kirin Tor Spirits force reaction

### DIFF
--- a/sql/updates/world/3.3.5/2017_08_28_00_world.sql
+++ b/sql/updates/world/3.3.5/2017_08_28_00_world.sql
@@ -1,0 +1,6 @@
+DELETE FROM `spell_area` WHERE `spell` BETWEEN 36216 AND 36219;
+INSERT INTO `spell_area` (`spell`, `area`, `quest_start`, `quest_end`, `aura_spell`, `racemask`, `gender`, `autocast`, `quest_start_status`, `quest_end_status`) VALUES 
+(36217, 3934, 10305, 0, 0, 0, 2, 1, 64, 11),
+(36218, 3934, 10306, 0, 0, 0, 2, 1, 64, 11),
+(36219, 3934, 10307, 0, 0, 0, 2, 1, 64, 11),
+(36216, 3924, 10182, 0, 0, 0, 2, 1, 64, 11);


### PR DESCRIPTION
Abjurist Belmara, Cohlien Frostweaver, Conjurer Luminrath and Battle-Mage Dathric each should become neutral to players once there associated quest is rewarded

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
