### PR TITLE
Core/Scripts: Removed wrong AddThreat call in Pursuit spellscript

### DIFF
--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
@@ -657,7 +657,6 @@ class spell_krick_pursuit : public SpellScriptLoader
                     ick->AddAura(GetSpellInfo()->Id, target);
                     ick->AI()->DoAction(ACTION_STORE_OLD_TARGET);
                     ick->GetThreatManager().AddThreat(target, float(GetEffectValue()), GetSpellInfo(), true, true);
-                    target->GetThreatManager().AddThreat(ick, float(GetEffectValue()), GetSpellInfo(), true, true);
                     ick->AI()->AttackStart(target);
                 }
             }


### PR DESCRIPTION
followup 52ad0c9e5c65a4add7dbcd9fac74c505aaa5b1cf
checked in sniffs, only ick add threat in target, wrong call in original script (why o keep it? o.o)

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
