### PR TITLE
Core/Movement: minor correction on WaypointMovementGenerator

### DIFF
--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -58,10 +58,7 @@ void WaypointMovementGenerator<Creature>::LoadPath(Creature* creature)
         return;
     }
 
-    _nextMoveTime.Reset(3000);
-
-    if (CanMove(creature))
-        StartMoveNow(creature);
+    _nextMoveTime.Reset(1000);
 }
 
 void WaypointMovementGenerator<Creature>::DoInitialize(Creature* creature)


### PR DESCRIPTION
remove the CanMove check since it will never trigger
the timer is left there to prevent errors on loading such as leader being created before the other members of the formation making them skip the first movement; purely a workaround

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
