### PR TITLE
DB/Quest: The Earthen Oath - Oathbound Warder ability spells

### DIFF
--- a/sql/updates/world/3.3.5/2017_11_13_00_world.sql
+++ b/sql/updates/world/3.3.5/2017_11_13_00_world.sql
@@ -1,0 +1,2 @@
+-- add Oathbound Warder ability spell1s to pet bar
+UPDATE `creature_template` SET `spell1`=56491, `Spell2`=56425, `Spell3`=56451, `Spell4`=56506 WHERE `entry`=30270;


### PR DESCRIPTION
- add missing spells to minions' pet bar

Closes #15456

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
