### PR TITLE
Core/Misc: Fix out of bounds access on startup

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2542,6 +2542,22 @@ void SpellMgr::LoadSpellInfoStore()
     for (SpellEntry const* spellEntry : sSpellStore)
         mSpellInfoMap[spellEntry->Id] = new SpellInfo(spellEntry);
 
+    for (uint32 spellIndex = 0; spellIndex < GetSpellInfoStoreSize(); ++spellIndex)
+    {
+        if (!mSpellInfoMap[spellIndex])
+            continue;
+
+        for (uint32 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; ++effectIndex)
+        {
+            if (mSpellInfoMap[spellIndex]->Effects[effectIndex].Effect >= TOTAL_SPELL_EFFECTS)
+            {
+                TC_LOG_ERROR("sql.sql", "Spell (Entry: %u) has `Effect` '%u' greater than max allowed value '%u', removing", spellIndex, mSpellInfoMap[spellIndex]->Effects[effectIndex].Effect, (TOTAL_SPELL_EFFECTS - 1));
+                mSpellInfoMap[spellIndex]->Effects[effectIndex].Effect = 0;
+            }
+        }
+    }
+
+
     TC_LOG_INFO("server.loading", ">> Loaded SpellInfo store in %u ms", GetMSTimeDiffToNow(oldMSTime));
 }
 


### PR DESCRIPTION
Fix out of bound access on startup trying to access SpellEffects with ID greater than max allowed/known.
Reported by AddressSanitizer .

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
