### PR TITLE
Revert "Scripts/Commands: Allow to use .tele in combat only to GMs"

### DIFF
--- a/src/server/scripts/Commands/cs_tele.cpp
+++ b/src/server/scripts/Commands/cs_tele.cpp
@@ -313,7 +313,7 @@ public:
             return false;
         }
 
-        if (me->IsInCombat() && !me->CanBeGameMaster())
+        if (me->IsInCombat() && !handler->GetSession()->HasPermission(rbac::RBAC_PERM_COMMAND_TELE_NAME))
         {
             handler->SendSysMessage(LANG_YOU_IN_COMBAT);
             handler->SetSentErrorMessage(true);


### PR DESCRIPTION
This reverts commit 3ae5b72075925f896c53603c26b2aa0dd7708fbf - see discussion on commit.

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
