### PR TITLE
Combat/Threat: Now set engaged state for all units on offline referen…

### DIFF
--- a/src/server/game/Combat/ThreatManager.cpp
+++ b/src/server/game/Combat/ThreatManager.cpp
@@ -372,13 +372,12 @@ void ThreatManager::AddThreat(Unit* target, float amount, SpellInfo const* spell
     ThreatReference* ref = new ThreatReference(this, target, amount);
     PutThreatListRef(target->GetGUID(), ref);
     target->GetThreatManager().PutThreatenedByMeRef(_owner->GetGUID(), ref);
-
-    Creature* cOwner = _owner->ToCreature();
-    ASSERT(cOwner); // if we got here the owner can have a threat list, and must be a creature!
-    if (!_ownerEngaged && (cOwner->HasReactState(REACT_PASSIVE) || !ref->IsOffline()))
+    if (!_ownerEngaged)
     {
         _ownerEngaged = true;
 
+        Creature* cOwner = _owner->ToCreature();
+        ASSERT(cOwner); // if we got here the owner can have a threat list, and must be a creature!
         SaveCreatureHomePositionIfNeed(cOwner);
         if (cOwner->IsAIEnabled)
             cOwner->AI()->JustEngagedWith(target);


### PR DESCRIPTION
…ce registration (vanished/invis'd units). For non-PASSIVE units, this will immediately cause an evade.

This fixes an exploit where creating the reference as offline (by vanishing while a spell was mid-flight) you could damage a creature further without it ever engaging you.

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
