### PR TITLE
Scripts/Icecrown Citadel: Corrected Val'kyr Shadowguard positioning o…

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -1519,10 +1519,8 @@ class npc_valkyr_shadowguard : public CreatureScript
 
             void ScheduleHeroicEvents()
             {
-                DoZoneInCombat();
                 _events.Reset();
                 _events.ScheduleEvent(EVENT_MOVE_TO_CENTER, 1);
-                _events.ScheduleEvent(EVENT_LIFE_SIPHON, 2000);
                 me->ClearUnitState(UNIT_STATE_EVADE);
             }
 
@@ -1560,11 +1558,14 @@ class npc_valkyr_shadowguard : public CreatureScript
                                 DoCast(target, SPELL_VALKYR_CARRY);
                                 _dropPoint.Relocate(triggers.front());
                                 _events.ScheduleEvent(EVENT_MOVE_TO_DROP_POS, 1500);
-
                             }
                         }
                         else
                             me->DespawnOrUnsummon();
+                        break;
+                    case POINT_SIPHON:
+                        DoZoneInCombat();
+                        _events.ScheduleEvent(EVENT_LIFE_SIPHON, 2000);
                         break;
                     default:
                         break;


### PR DESCRIPTION
…n heroic mode (Lich King)

Movement was being prevented by spell cast

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
