### PR TITLE
Scripts/ICC: Valithria Dreamwalker's script no longer despawns unrela…

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
@@ -231,9 +231,25 @@ class ValithriaDespawner : public BasicEvent
 
         void operator()(Creature* creature) const
         {
-            if (creature->GetEntry() == NPC_VALITHRIA_DREAMWALKER)
-                if (InstanceScript* instance = creature->GetInstanceScript())
-                    instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, creature);
+            switch (creature->GetEntry())
+            {
+                case NPC_VALITHRIA_DREAMWALKER:
+                    if (InstanceScript* instance = creature->GetInstanceScript())
+                        instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, creature);
+                    // no break
+                case NPC_BLAZING_SKELETON:
+                case NPC_SUPPRESSER:
+                case NPC_BLISTERING_ZOMBIE:
+                case NPC_GLUTTONOUS_ABOMINATION:
+                case NPC_MANA_VOID:
+                case NPC_COLUMN_OF_FROST:
+                case NPC_ROT_WORM:
+                case NPC_RISEN_ARCHMAGE:
+                    break;
+                default:
+                    return;
+            }
+                
             creature->DespawnOrUnsummon(0, 10s);
         }
 


### PR DESCRIPTION
…ted mobs in Frostwing Halls, and thus won't get them stuck in a despawned state due to linked_respawn.

Closes #21286.

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
