### PR TITLE
Revert "Scripts/Northrend: Malygos now uses modifiable threat list wh…

### DIFF
--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
@@ -1825,8 +1825,7 @@ class spell_malygos_vortex_visual : public SpellScriptLoader
             {
                 if (Creature* caster = GetCaster()->ToCreature())
                 {
-                    // we need modifiable threat list here - SPELL_VORTEX_6 is a TELEPORT effect, which may stop combat
-                    for (ThreatReference const* ref : caster->GetThreatManager().GetModifiableThreatList())
+                    for (ThreatReference const* ref : caster->GetThreatManager().GetUnsortedThreatList())
                     {
                         if (Player* targetPlayer = ref->GetVictim()->ToPlayer())
                         {


### PR DESCRIPTION
…en teleporting after vortex. Fixes a crash. Closes #21315."

This reverts commit 6bbc95f3a0078e5d121e7092a60fa85b24c725d9, which is made unnecessary by 65709e1c3081c97442792695cbc0f0826015d625.

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
