### PR TITLE
DB: Add a missing action_param to  the previous commit

### DIFF
--- a/sql/updates/world/3.3.5/2018_02_13_02_world.sql
+++ b/sql/updates/world/3.3.5/2018_02_13_02_world.sql
@@ -1,0 +1,2 @@
+-- 
+UPDATE `smart_scripts` SET `action_param1`=180 WHERE `source_type`=9 AND `entryorguid`=2878000 AND `id` IN (7); 


### PR DESCRIPTION
Gobs always requires respawn time with the action 41, otherwise they will never respawn

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
