### PR TITLE
DB/Loot: add missing column name to 2018_02_13_00_world_335.sql

### DIFF
--- a/sql/updates/world/3.3.5/2018_02_13_00_world_335.sql
+++ b/sql/updates/world/3.3.5/2018_02_13_00_world_335.sql
@@ -3,7 +3,7 @@ DELETE FROM `reference_loot_template` WHERE `Entry`=24064 AND `Item` IN (911, 92
 
 -- Add former items from reference table 24064 to their proper NPCs
 DELETE FROM `creature_loot_template` WHERE `Item` IN (911, 920, 1076, 1406, 1455, 2034, 2232, 3429);
-INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Chance`, `GroupId`) VALUES
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Chance`, `GroupId`, `Comment`) VALUES
 (889,  911,  0.1, 0, "Splinter Fist Ogre - Ironwood Treebranch"),
 (215,  920,  0.1, 0, "Defias Night Runner - Wicked Spiked Mace"),
 (909,  920,  0.1, 0, "Defias Night Blade - Wicked Spiked Mace"),


### PR DESCRIPTION
Error message upon loading the original file into DB:
- ERROR 1136 (21S01) at line 6: Column count doesn't match value count at row 1

Closes #21407

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
