### PR TITLE
Core/Threat: Fix taunt logic relying on unspecified behavior by unord…

### DIFF
--- a/src/server/game/Combat/ThreatManager.cpp
+++ b/src/server/game/Combat/ThreatManager.cpp
@@ -396,26 +396,16 @@ void ThreatManager::MatchUnitThreatToHighestThreat(Unit* target)
     if (_sortedThreatList.empty())
         return;
 
-    auto it = _sortedThreatList.begin(), end = _sortedThreatList.end();
+    auto it = _sortedThreatList.ordered_begin(), end = _sortedThreatList.ordered_end();
     ThreatReference const* highest = *it;
-    if (!highest->IsOnline())
+    if (!highest->IsAvailable())
         return;
 
-    if (highest->_taunted) // might need to skip this - new max could be one of the preceding elements (heap property) since there is only one taunt element
+    if (highest->IsTaunting() && ((++it) != end)) // might need to skip this - max threat could be the preceding element (there is only one taunt element)
     {
-        if ((++it) != end)
-        {
-            ThreatReference const* a = *it;
-            if (a->IsOnline() && a->GetThreat() > highest->GetThreat())
-                highest = a;
-
-            if ((++it) != end)
-            {
-                a = *it;
-                if (a->IsOnline() && a->GetThreat() > highest->GetThreat())
-                    highest = a;
-            }
-        }
+        ThreatReference const* a = *it;
+        if (a->IsAvailable() && a->GetThreat() > highest->GetThreat())
+            highest = a;
     }
 
     AddThreat(target, highest->GetThreat() - GetThreat(target, true), nullptr, true, true);
@@ -432,7 +422,7 @@ void ThreatManager::TauntUpdate()
         auto threatIt = _myThreatListEntries.find((*it)->GetCasterGUID());
         if (threatIt == threatEnd)
             continue;
-        if (!threatIt->second->IsOnline())
+        if (!threatIt->second->IsAvailable())
             continue;
         tauntRef = threatIt->second;
         break;
@@ -716,7 +706,7 @@ void ThreatManager::PurgeThreatListRef(ObjectGuid const& guid, bool sendRemove)
         _currentVictimRef = nullptr;
 
     _sortedThreatList.erase(ref->_handle);
-    if (sendRemove && ref->IsOnline())
+    if (sendRemove && ref->IsAvailable())
         SendRemoveToClients(ref->_victim);
 }
 


### PR DESCRIPTION
…ered boost heap iterators. Use ordered iterators instead, this is cheap for our use case anyway. This will make taunt behave consistently again.

Closes #21499.

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
