### PR TITLE
Core/Creature: Temporarily let Creatures violate dynspawn assumptions…

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1635,13 +1635,14 @@ bool Creature::LoadFromDB(ObjectGuid::LowType spawnId, Map* map, bool addToMap, 
 
     if (!m_respawnTime && !map->IsSpawnGroupActive(data->spawnGroupData->groupId))
     {
-        ASSERT(m_respawnCompatibilityMode, "Creature (SpawnID %u) trying to load in inactive spawn group %s.", spawnId, data->spawnGroupData->name.c_str());
+        // @todo pools need fixing! this is just a temporary crashfix, but they violate dynspawn principles
+        ASSERT(m_respawnCompatibilityMode || sPoolMgr->IsPartOfAPool<Creature>(spawnId), "Creature (SpawnID %u) trying to load in inactive spawn group %s.", spawnId, data->spawnGroupData->name.c_str());
         m_respawnTime = GameTime::GetGameTime() + urand(4, 7);
     }
 
     if (m_respawnTime)                          // respawn on Update
     {
-        ASSERT(m_respawnCompatibilityMode, "Creature (SpawnID %u) trying to load despite a respawn timer in progress.", spawnId);
+        ASSERT(m_respawnCompatibilityMode || sPoolMgr->IsPartOfAPool<Creature>(spawnId), "Creature (SpawnID %u) trying to load despite a respawn timer in progress.", spawnId);
         m_deathState = DEAD;
         if (CanFly())
         {


### PR DESCRIPTION
… for pooled creatures. This should fix startup crashes until I can investigate and find a long-term fix. Tag #21519.

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
