### PR TITLE
Core/Movement: Correct distance checking

### DIFF
--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -72,10 +72,7 @@ bool TargetedMovementGenerator<T, D>::DoUpdate(T* owner, uint32 diff)
                 transport->CalculatePassengerPosition(destination.x, destination.y, destination.z);
 
         // First check distance
-        if (owner->GetTypeId() == TYPEID_UNIT && owner->ToCreature()->CanFly())
-            targetMoved = !GetTarget()->IsInDist(destination.x, destination.y, destination.z, distance);
-        else
-            targetMoved = !GetTarget()->IsInDist2d(destination.x, destination.y, distance);
+        targetMoved = !GetTarget()->IsInDist(destination.x, destination.y, destination.z, distance);
 
         // then, if the target is in range, check also Line of Sight.
         if (!targetMoved)


### PR DESCRIPTION
Distance checking should always be in 3D, independently on if the mover has the ability to fly or not.

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
