### PR TITLE
DB/Quest: Greed completion text (Blood Elf rogue lock pick class quest)

### DIFF
--- a/sql/updates/world/3.3.5/2018_03_17_05_world_335.sql
+++ b/sql/updates/world/3.3.5/2018_03_17_05_world_335.sql
@@ -1,0 +1,2 @@
+-- Blood Elf rogue quest Greed (ID 9491)
+UPDATE `quest_offer_reward` SET `RewardText`="This is the ring, is it? Not much to look at, but you know what they say about one elves' trash...$B$BAnd let's not forget your payment. Don't feel shy about spending it right here sweetie!" WHERE `ID`=9491;


### PR DESCRIPTION
Replace "sister" with "sweetie" (gender neutral) as last word in Reward text.

Sources:
- https://wow.gamepedia.com/Quest:Greed#Completion
- http://wowwiki.wikia.com/wiki/Quest%3AGreed#Completion
- http://web.archive.org/web/20100808103416/http://www.wowhead.com:80/quest=9491

BTW, regarding the grammatical error in "one elves' trash" -- Blizzlike, sadly.

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
