### PR TITLE
Core/Movement: crashfix

### DIFF
--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -161,9 +161,13 @@ void MotionMaster::MovementExpired(bool reset /*= true*/)
 MovementGeneratorType MotionMaster::GetCurrentMovementGeneratorType() const
 {
     if (empty())
-        return IDLE_MOTION_TYPE;
+        return MAX_MOTION_TYPE;
 
-    return top()->GetMovementGeneratorType();
+    MovementGenerator* movement = top();
+    if (!movement)
+        return MAX_MOTION_TYPE;
+
+    return movement->GetMovementGeneratorType();
 }
 
 MovementGeneratorType MotionMaster::GetMotionSlotType(MovementSlot slot) const


### PR DESCRIPTION
New movement -> Mutate -> Finish current for that slot that happens to be the same type, Follow -> Finish method on the removed movement -> UpdateSpeed call -> search for top -> crash

Closes #21861

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
