### PR TITLE
Dep/Boost: Fix crash in Boost

### DIFF
--- a/src/common/Asio/Resolver.h
+++ b/src/common/Asio/Resolver.h
@@ -32,7 +32,7 @@ namespace Trinity
             boost::system::error_code ec;
 #if BOOST_VERSION >= 106600
             boost::asio::ip::tcp::resolver::results_type results = resolver.resolve(protocol, host, service, ec);
-            if (results.empty() || ec)
+            if (results.begin() == results.end() || ec)
                 return {};
 
             return results.begin()->endpoint();


### PR DESCRIPTION
Work around a NULL dereference exception happening in boost::asio::ip::tcp::resolver::results_type, resulting in a crash when trying to bind on an address that cannot be resolved.
Fixes #21884

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
