### PR TITLE
Scripts/Sunken Temple: normalize Atal'alarion despawn timer (#22546)

### DIFF
--- a/src/server/scripts/EasternKingdoms/SunkenTemple/instance_sunken_temple.cpp
+++ b/src/server/scripts/EasternKingdoms/SunkenTemple/instance_sunken_temple.cpp
@@ -187,7 +187,7 @@ public:
             for (uint8 i = 0; i < nStatues; ++i)
                 go->SummonGameObject(GO_ATALAI_LIGHT2, statuePositions[i], QuaternionData(), 0);
 
-            go->SummonCreature(NPC_ATALALARION, atalalarianPos, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 7200);
+            go->SummonCreature(NPC_ATALALARION, atalalarianPos, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 600000);
         }
 
          void SetData(uint32 type, uint32 data) override


### PR DESCRIPTION
* Atal'Alarion will now despawn as a regular Elite mob
  (5 minutes unlooted or 2.5 minutes when fully looted)
  instead of 7200 (ms) (7.2 seconds) before this change.

Closes #22531

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
