### PR TITLE
Fix invalid arguments to string format in Trinity::Fatal

### DIFF
--- a/src/common/Debugging/Errors.cpp
+++ b/src/common/Debugging/Errors.cpp
@@ -96,7 +96,7 @@ void Fatal(char const* file, int line, char const* function, char const* message
     va_list args;
     va_start(args, message);
 
-    std::string formattedMessage = StringFormat("\n%s:%i in %s FATAL ERROR:\n  %s\n", file, line, function) + FormatAssertionMessage(message, args) + '\n';
+    std::string formattedMessage = StringFormat("\n%s:%i in %s FATAL ERROR:\n", file, line, function) + FormatAssertionMessage(message, args) + '\n';
     va_end(args);
 
     fprintf(stderr, "%s", formattedMessage.c_str());


### PR DESCRIPTION
Isn't whatever is used nowadays to make this stuff safe supposed to prevent this sort of stuff?

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
