### PR TITLE
Core/Misc: Fix vsnprintf usage in ASSERT()

### DIFF
--- a/src/common/Debugging/Errors.cpp
+++ b/src/common/Debugging/Errors.cpp
@@ -60,7 +60,7 @@ namespace
         va_end(len);
 
         formatted.resize(length);
-        vsnprintf(&formatted[0], length, format, args);
+        vsnprintf(&formatted[0], length + 1, format, args);
 
         return formatted;
     }


### PR DESCRIPTION
Fix vsnprintf to follow standard definition and not some old VC++ behavior, not requiring to include the '\0' character in the count parameter

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
