### PR TITLE
Scripts/Misc: Fix LoadMinionData() dynamic analysis issues

### DIFF
--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/instance_utgarde_keep.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/instance_utgarde_keep.cpp
@@ -32,7 +32,8 @@ DoorData const doorData[] =
 MinionData const minionData[] =
 {
     { NPC_SKARVALD,     DATA_SKARVALD_DALRONN },
-    { NPC_DALRONN,      DATA_SKARVALD_DALRONN }
+    { NPC_DALRONN,      DATA_SKARVALD_DALRONN },
+    { 0,                0 }
 };
 
 class instance_utgarde_keep : public InstanceMapScript

--- a/src/server/scripts/Outland/GruulsLair/instance_gruuls_lair.cpp
+++ b/src/server/scripts/Outland/GruulsLair/instance_gruuls_lair.cpp
@@ -34,7 +34,8 @@ MinionData const minionData[] =
     { NPC_KROSH_FIREHAND,       DATA_MAULGAR },
     { NPC_OLM_THE_SUMMONER,     DATA_MAULGAR },
     { NPC_KIGGLER_THE_CRAZED,   DATA_MAULGAR },
-    { NPC_BLINDEYE_THE_SEER,    DATA_MAULGAR }
+    { NPC_BLINDEYE_THE_SEER,    DATA_MAULGAR },
+    { 0, 0 }
 };
 
 class instance_gruuls_lair : public InstanceMapScript


### PR DESCRIPTION
Fix issues reported by Address Sanitizer about LoadMinionData() calls on arrays that don't end with a {0, 0} pair.

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
