### PR TITLE
Core/MMaps: Fix infinite loop in Detour

### DIFF
--- a/dep/recastnavigation/Detour/Source/DetourNavMeshQuery.cpp
+++ b/dep/recastnavigation/Detour/Source/DetourNavMeshQuery.cpp
@@ -26,6 +26,7 @@
 #include "DetourAlloc.h"
 #include "DetourAssert.h"
 #include <new>
+#include <unordered_set>
 
 /// @class dtQueryFilter
 ///
@@ -1206,10 +1207,16 @@ dtStatus dtNavMeshQuery::getPathToNode(dtNode* endNode, dtPolyRef* path, int* pa
 	// Find the length of the entire path.
 	dtNode* curNode = endNode;
 	int length = 0;
+	std::unordered_set<int> processedIds;
+	bool alreadyProcessed = false;
 	do
 	{
 		length++;
+		alreadyProcessed = !processedIds.insert(curNode->pidx).second;
+		if (alreadyProcessed)
+			return DT_FAILURE;
 		curNode = m_nodePool->getNodeAtIdx(curNode->pidx);
+
 	} while (curNode);
 
 	// If the path cannot be fully stored then advance to the last node we will be able to store.

--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -395,7 +395,7 @@ void PathGenerator::BuildPolyPath(G3D::Vector3 const& startPos, G3D::Vector3 con
             // this is probably an error state, but we'll leave it
             // and hopefully recover on the next Update
             // we still need to copy our preffix
-            TC_LOG_ERROR("maps", "%u's Path Build failed: 0 length path", _sourceUnit->GetGUID().GetCounter());
+            TC_LOG_ERROR("maps", "Path Build failed\n%s", _sourceUnit->GetDebugInfo().c_str());
         }
 
         TC_LOG_DEBUG("maps", "++  m_polyLength=%u prefixPolyLength=%u suffixPolyLength=%u \n", _polyLength, prefixPolyLength, suffixPolyLength);


### PR DESCRIPTION
Fix an infinite loop in Detour happening in Dalaran Sewers.
This is more of an emergency patch until we figure out why dtNodes have a circular reference (A -> B -> C -> A) happening quite often in this place

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
